### PR TITLE
port thin-pdo-wrapper to 2016

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2011 Louis Stowasser 
+Copyright (c) 2010-2016 Louis Stowasser, Billy Lamberta
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
This pull request ports `thin-pdo-wrapper` to meet the style and technical demands of a modern day pdo wrapper in 2016. We hope to reconcile the great work that @louisstow has done keeping `thin-pdo-wrapper` up-to-date and relevant with new features, while also preserving backward compatibility with @mikehenrty's abandonware and to remain stable enough for Enterprise deployments.
Looking forward, I hope one day we can reunite the two communities, and to that end I propose a new thin-pdo-wrapper governing board consisting of Louis, @CarlQLange, and myself, that will make decisions for the project and shepherd it into the future.
